### PR TITLE
give us the text being modified in BeforeModified events on Undo/Redo

### DIFF
--- a/Shared/BeforeModificationEventArgs.cs
+++ b/Shared/BeforeModificationEventArgs.cs
@@ -42,9 +42,6 @@ public class BeforeModificationEventArgs : EventArgs
     /// <returns>
     /// The text about to be inserted or deleted.
     /// </returns>
-    /// <remarks>
-    /// This property will return null when <see cref="Source" /> is <see cref="ModificationSource.Undo" /> or <see cref="ModificationSource.Redo" />.
-    /// </remarks>
     public unsafe virtual string Text
     {
         get

--- a/Shared/BeforeModificationEventArgs.cs
+++ b/Shared/BeforeModificationEventArgs.cs
@@ -40,7 +40,7 @@ public class BeforeModificationEventArgs : EventArgs
     /// Gets the text being inserted or deleted.
     /// </summary>
     /// <returns>
-    /// The text about to be inserted or deleted, or null when the the source of the modification is an undo/redo operation.
+    /// The text about to be inserted or deleted.
     /// </returns>
     /// <remarks>
     /// This property will return null when <see cref="Source" /> is <see cref="ModificationSource.Undo" /> or <see cref="ModificationSource.Redo" />.
@@ -49,9 +49,6 @@ public class BeforeModificationEventArgs : EventArgs
     {
         get
         {
-            if (Source != ModificationSource.User)
-                return null;
-
             if (CachedText == null)
             {
                 // For some reason the Scintilla overlords don't provide text in


### PR DESCRIPTION
see #54

We need this for the length of the affected range because Scintilla.NET doesn't expose the length property of the modification event.