### PR TITLE
Fix assembly path resolving

### DIFF
--- a/Scintilla.NET/Scintilla.NET.csproj
+++ b/Scintilla.NET/Scintilla.NET.csproj
@@ -8,7 +8,7 @@
 		<NeutralLanguage>en-US</NeutralLanguage>
 		<Description>Source Editing Component based on Scintilla 5 series.</Description>
 		<Copyright>Copyright (c) 2018, Jacob Slusser. All rights reserved. VPKSoft, cyber960 2022.</Copyright>
-		<Version>5.3.2.6</Version>
+		<Version>5.3.2.7</Version>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<DocumentationFile>bin\$(Configuration)\ScintillaNET.xml</DocumentationFile>
 		<UseWindowsForms>true</UseWindowsForms>

--- a/Shared/Scintilla.cs
+++ b/Shared/Scintilla.cs
@@ -45,7 +45,7 @@ namespace ScintillaNET
         private static string LocateNativeDllDirectory()
         {
             string platform = (IntPtr.Size == 4 ? "x86" : "x64");
-            string managedLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string managedLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? AppDomain.CurrentDomain.BaseDirectory;
             var basePath = Path.Combine(managedLocation, platform);
             
             // Directory exists when application is built, but not if Scintilla is dragged on in the Winforms designer


### PR DESCRIPTION
Fall back to `AppDomain.CurrentDomain.BaseDirectory` when `Assembly.GetExecutingAssembly().Location` is `null`.

Closes #63 